### PR TITLE
Fix issue with name collision between previous for loop

### DIFF
--- a/plugin/angular-cli.vim
+++ b/plugin/angular-cli.vim
@@ -34,8 +34,8 @@ function! CreateEditCommands()
         \  'Service',
         \  'Pipe',
         \  'Ng' ]
-    for element in elements_without_relation
-      silent execute 'command! -nargs=1 -complete=customlist,'. element . 'Files ' mode[0] . element . ' call EditFile(<f-args>, "' . mode[1] .'")'
+    for elt in elements_without_relation
+      silent execute 'command! -nargs=1 -complete=customlist,'. elt . 'Files ' mode[0] . elt . ' call EditFile(<f-args>, "' . mode[1] .'")'
     endfor
   endfor
 


### PR DESCRIPTION
Hi,

I had the following error message when using your plugin and doing the fix in this pr solve the problem.

> Error detected while processing function CreateEditCommands:
line   19:
E706: Variable type mismatch for: element
line   20:
E730: using List as a String
E15: Invalid expression: 'command! -nargs=1 -complete=customlist,'. element . 'Files ' mode[0] . element . ' call EditFile(<f-args>, "' . mode[1] .'")'
line   19:
E706: Variable type mismatch for: element
line   20:
E730: using List as a String
E15: Invalid expression: 'command! -nargs=1 -complete=customlist,'. element . 'Files ' mode[0] . element . ' call EditFile(<f-args>, "' . mode[1] .'")'
line   19:
E706: Variable type mismatch for: element
line   20:
E730: using List as a String
E15: Invalid expression: 'command! -nargs=1 -complete=customlist,'. element . 'Files ' mode[0] . element . ' call EditFile(<f-args>, "' . mode[1] .'")'
line   19:
E706: Variable type mismatch for: element
line   20:
E730: using List as a String
E15: Invalid expression: 'command! -nargs=1 -complete=customlist,'. element . 'Files ' mode[0] . element . ' call EditFile(<f-args>, "' . mode[1] .'")'
line   19:
E706: Variable type mismatch for: element
line   20:
E730: using List as a String
E15: Invalid expression: 'command! -nargs=1 -complete=customlist,'. element . 'Files ' mode[0] . element . ' call EditFile(<f-args>, "' . mode[1] .'")'
line   19:
E706: Variable type mismatch for: element
line   20:
E730: using List as a String
E15: Invalid expression: 'command! -nargs=1 -complete=customlist,'. element . 'Files ' mode[0] . element . ' call EditFile(<f-args>, "' . mode[1] .'")'
line   19:
E706: Variable type mismatch for: element
line   20:
E730: using List as a String
E15: Invalid expression: 'command! -nargs=1 -complete=customlist,'. element . 'Files ' mode[0] . element . ' call EditFile(<f-args>, "' . mode[1] .'")'
line   19:
E706: Variable type mismatch for: element
line   20:
E730: using List as a String
E15: Invalid expression: 'command! -nargs=1 -complete=customlist,'. element . 'Files ' mode[0] . element . ' call EditFile(<f-args>, "' . mode[1] .'")'

This error occured on vim 7.4.160 on CentOS 7. I thought I might share it, it might be helpful. There might be a deeper problem or the issue is on my side, I am not fluent in vimscript so I wouldn't know!