### PR TITLE
Support default style ext from angular.json by Angular6.

### DIFF
--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -70,8 +70,9 @@ function! angular_cli#CreateGenerateCommands() abort
 endfunction
 
 function! angular_cli#CreateDefaultStyleExt() abort
-  let re = "\'" . '(?<=styleExt.:..).+(?=..)' . "\'"
-  let g:angular_cli_stylesheet_format = system('grep -Po ' . re . ' .angular-cli.json')[:-2]
+  let re = "\'" . '(?<=(?i)styleext.:..)\w+' . "\'"
+  let target = empty(glob('angular.json')) ? ' .angular-cli.json' : ' angular.json'
+  let g:angular_cli_stylesheet_format = system('grep -Po ' . re . target)[:-2]
 endfunction
 
 function! angular_cli#CreateDestroyCommand() abort


### PR DESCRIPTION
Angular 6 has created an `angular.json` file.

A fixed code is needed because `angular.json` was original ` .angular-cli.json`.

---

Angular6では`angular.json`というファイルが作成されるようになりました。

これは、もともと`.angular-cli.json`であったため、`angular.json`にも対応した修正コードが必要です。