### PR TITLE
:ESpec a second time jumps back, g:gnu_grep for mac users, default to .scss in Ionic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ The command supports autocompletion for the corresponding file type.
 The elements marked with '*' are available without arguments. In this case, the plugin will try to open the directly related file.
 for instance, if `ESpec` is called without arguments while editing the component app.component.ts, it will try to open the corresponding spec file, app.component.spec.ts.
 
-Stylesheet format is set automatically to the corresponding styleExt value from `.angular-cli.json`.
+`ESpec` will also try to bounce you back to the file you left as long as you don't leave the buffer.
+
+Stylesheet format is set automatically to the corresponding styleExt value from `angular.json` or `.angular-cli.json` depending on the project version.  
+
+If neither exists, and `g:angular_cli_stylesheet_format` is not set manually, assume an Ionic project triggered the plugin and set to `scss`.
+
+**Note to macOS users:** macOS grep is not compatible with GNU grep. You can install GNU grep under a different name (ggrep or whatever) and set `g:gnu_grep = 'ggrep'` to fix stylesheet autodetection if you don't want to set it manually for every project. (If you overwrite the system grep command with GNU grep then you're good)
 
 ## The S, V, T Commands (Split, VSplit, Tabnew)
 Similar to the E command, except that the files are edited in a horizontal split (S), vertical split (V), new tab (T) respectively.

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -73,7 +73,6 @@ function! angular_cli#CreateDefaultStyleExt() abort
   let re = "\'" . '(?<=(?i)styleext.:..)\w+' . "\'"
   let target = empty(glob('angular.json')) ? ' .angular-cli.json' : ' angular.json'
   let g:angular_cli_stylesheet_format = system(g:gnu_grep . ' -Po ' . re . target)[:-2]
-  echom g:angular_cli_stylesheet_format
   " if this plugin was loaded but no ng config found, assume ionic 
   " (default .scss)
   if v:shell_error

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -70,9 +70,9 @@ function! angular_cli#CreateGenerateCommands() abort
 endfunction
 
 function! angular_cli#CreateDefaultStyleExt() abort
-  let re = "\'" . '(?<=(?i)styleext.:..)\w+' . "\'"
+  let re = "\'" . '(?<=styles\.).*(?=")' . "\'"
   let target = empty(glob('angular.json')) ? ' .angular-cli.json' : ' angular.json'
-  let g:angular_cli_stylesheet_format = system(g:gnu_grep . ' -Po ' . re . target)[:-2]
+  let g:angular_cli_stylesheet_format = systemlist(g:gnu_grep . ' -Po ' . re . target)[0]
   " if this plugin was loaded but no ng config found, assume ionic 
   " (default .scss)
   if v:shell_error

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -30,7 +30,7 @@ function! angular_cli#CreateEditCommands() abort
           \[ ['Component', 'component.ts'],
           \  ['Module', 'module.ts'],
           \  ['Template', 'component.html'],
-          \  ['Spec', 'spec.ts'],
+          \  ['Spec', 'component.spec.ts'],
           \  ['Stylesheet', 'component.' . g:angular_cli_stylesheet_format] ]
     for element in elements_with_relation
       silent execute 'command! -nargs=? -complete=customlist,angular_cli#' . element[0] .'Files ' . mode[0] . element[0] . ' call angular_cli#EditRelatedFile(<q-args>, "'. mode[1] .'", "' .element[1]. '")'
@@ -178,8 +178,8 @@ function! angular_cli#EditSpecFile(file, command) abort
     let g:last_file_jump = expand('%')
     let base_file = substitute(expand('%'), '.html', '', '')
     let base_file = substitute(base_file, '.ts', '', '')
-    let base_file = substitute(base_file, g:angular_cli_stylesheet_format, '', '')
-    let file = base_file . 'component.spec.ts'
+    let base_file = substitute(base_file, '.' . g:angular_cli_stylesheet_format, '', '')
+    let file = base_file . '.spec.ts'
   endif 
   call angular_cli#EditFileIfExist(file, a:command, '.ts')
 endfunction

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -70,10 +70,10 @@ function! angular_cli#CreateGenerateCommands() abort
 endfunction
 
 function! angular_cli#CreateDefaultStyleExt() abort
-  let re = "\'" . '(?<=styleExt.:..).+(?=..)' . "\'"
-  let target = empty(glob('angular.json')) ? ' .angular-cli.json' : ' .angular.json'
+  let re = "\'" . '(?<=(?i)styleext.:..)\w+' . "\'"
+  let target = empty(glob('angular.json')) ? ' .angular-cli.json' : ' angular.json'
   let g:angular_cli_stylesheet_format = system(g:gnu_grep . ' -Po ' . re . target)[:-2]
-
+  echom g:angular_cli_stylesheet_format
   " if this plugin was loaded but no ng config found, assume ionic 
   " (default .scss)
   if v:shell_error
@@ -179,7 +179,8 @@ function! angular_cli#EditSpecFile(file, command) abort
     let g:last_file_jump = expand('%')
     let base_file = substitute(expand('%'), '.html', '', '')
     let base_file = substitute(base_file, '.ts', '', '')
-    let file = base_file . '.spec.ts'
+    let base_file = substitute(base_file, g:angular_cli_stylesheet_format, '', '')
+    let file = base_file . 'component.spec.ts'
   endif 
   call angular_cli#EditFileIfExist(file, a:command, '.ts')
 endfunction

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -26,8 +26,6 @@ function! angular_cli#CreateEditCommands() abort
         \  ['V', 'vsplit'],
         \  ['T', 'tabnew'] ]
   for mode in modes
-    " TODO: ionic 4 with angular 6+ uses component.html and page.html, an
-    " elegant solution will solve for both.
     let elements_with_relation = 
           \[ ['Component', 'component.ts'],
           \  ['Module', 'module.ts'],
@@ -73,9 +71,11 @@ endfunction
 
 function! angular_cli#CreateDefaultStyleExt() abort
   let re = "\'" . '(?<=styleExt.:..).+(?=..)' . "\'"
-  let g:angular_cli_stylesheet_format = system(g:gnu_grep . ' -Po ' . re . ' angular.json')[:-2]
-  " assuming the correct grep command is set, if this is loaded but no
-  " .angular-cli is found, its probably ionic3 (scss)
+  let target = empty(glob('angular.json')) ? ' .angular-cli.json' : ' .angular.json'
+  let g:angular_cli_stylesheet_format = system(g:gnu_grep . ' -Po ' . re . target)[:-2]
+
+  " if this plugin was loaded but no ng config found, assume ionic 
+  " (default .scss)
   if v:shell_error
     let g:angular_cli_stylesheet_format = 'scss'
   endif
@@ -170,23 +170,17 @@ function! angular_cli#EditFileIfExist(file, command, extension) abort
 endfunction
 
 function! angular_cli#EditSpecFile(file, command) abort
-  "TODO: check the jump list: if the most recent jump was from a file with the
-  "same base name (i.e. home.whatever.spec.ts -> home.whatever.html) then
-  ":ESpec will jump back. Maybe vim-go's :GoAlternate handles this better.
   let file = a:file
   if file == ''
+    if expand('%') =~ 'component.spec.ts'
+      execute 'edit' g:last_file_jump
+      return
+    endif
+    let g:last_file_jump = expand('%')
     let base_file = substitute(expand('%'), '.html', '', '')
     let base_file = substitute(base_file, '.ts', '', '')
-
-    " just cover everything
-    let base_file = substitute(base_file, '.css', '', '')
-    let base_file = substitute(base_file, '.scss', '', '')
-    let base_file = substitute(base_file, '.less', '', '')
     let file = base_file . '.spec.ts'
   endif 
-  if expand('%') =~ 'component.spec.ts'
-    return
-  endif
   call angular_cli#EditFileIfExist(file, a:command, '.ts')
 endfunction
 

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -170,6 +170,9 @@ function! angular_cli#EditFileIfExist(file, command, extension) abort
 endfunction
 
 function! angular_cli#EditSpecFile(file, command) abort
+  "TODO: check the jump list: if the most recent jump was from a file with the
+  "same base name (i.e. home.whatever.spec.ts -> home.whatever.html) then
+  ":ESpec will jump back. Maybe vim-go's :GoAlternate handles this better.
   let file = a:file
   if file == ''
     let base_file = substitute(expand('%'), '.html', '', '')

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -26,6 +26,8 @@ function! angular_cli#CreateEditCommands() abort
         \  ['V', 'vsplit'],
         \  ['T', 'tabnew'] ]
   for mode in modes
+    " TODO: ionic 4 with angular 6+ uses component.html and page.html, an
+    " elegant solution will solve for both.
     let elements_with_relation = 
           \[ ['Component', 'component.ts'],
           \  ['Module', 'module.ts'],
@@ -71,11 +73,11 @@ endfunction
 
 function! angular_cli#CreateDefaultStyleExt() abort
   let re = "\'" . '(?<=styleExt.:..).+(?=..)' . "\'"
-  let g:angular_cli_stylesheet_format = system(g:gnu_grep . ' -Po ' . re . ' .angular-cli.json')[:-2]
+  let g:angular_cli_stylesheet_format = system(g:gnu_grep . ' -Po ' . re . ' angular.json')[:-2]
   " assuming the correct grep command is set, if this is loaded but no
   " .angular-cli is found, its probably ionic3 (scss)
   if v:shell_error
-    g:angular_cli_stylesheet_format = 'scss'
+    let g:angular_cli_stylesheet_format = 'scss'
   endif
 endfunction
 

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -168,7 +168,11 @@ function! angular_cli#EditSpecFile(file, command) abort
   if file == ''
     let base_file = substitute(expand('%'), '.html', '', '')
     let base_file = substitute(base_file, '.ts', '', '')
-    let base_file = substitute(base_file, '.' . g:angular_cli_stylesheet_format, '', '')
+
+    " just cover everything
+    let base_file = substitute(base_file, '.css', '', '')
+    let base_file = substitute(base_file, '.scss', '', '')
+    let base_file = substitute(base_file, '.less', '', '')
     let file = base_file . '.spec.ts'
   endif 
   if expand('%') =~ 'component.spec.ts'

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -70,8 +70,9 @@ function! angular_cli#CreateGenerateCommands() abort
 endfunction
 
 function! angular_cli#CreateDefaultStyleExt() abort
-  let re = "\'" . '(?<=styleExt.:..).+(?=..)' . "\'"
-  let g:angular_cli_stylesheet_format = system('grep -Po ' . re . ' .angular-cli.json')[:-2]
+  let re = "\'" . '(?<=(?i)styleext.:..)\w+' . "\'"
+  let target = empty(glob('angular.json')) ? ' .angular-cli.json' : ' angular.json'
+  let g:angular_cli_stylesheet_format = system('grep -Po ' . re . target)[:-2]
 endfunction
 
 function! angular_cli#CreateDestroyCommand() abort

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -71,7 +71,12 @@ endfunction
 
 function! angular_cli#CreateDefaultStyleExt() abort
   let re = "\'" . '(?<=styleExt.:..).+(?=..)' . "\'"
-  let g:angular_cli_stylesheet_format = system('grep -Po ' . re . ' .angular-cli.json')[:-2]
+  let g:angular_cli_stylesheet_format = system(g:gnu_grep . ' -Po ' . re . ' .angular-cli.json')[:-2]
+  " assuming the correct grep command is set, if this is loaded but no
+  " .angular-cli is found, its probably ionic3 (scss)
+  if v:shell_error
+    g:angular_cli_stylesheet_format = 'scss'
+  endif
 endfunction
 
 function! angular_cli#CreateDestroyCommand() abort
@@ -167,7 +172,11 @@ function! angular_cli#EditSpecFile(file, command) abort
   if file == ''
     let base_file = substitute(expand('%'), '.html', '', '')
     let base_file = substitute(base_file, '.ts', '', '')
-    let base_file = substitute(base_file, '.' . g:angular_cli_stylesheet_format, '', '')
+
+    " just cover everything
+    let base_file = substitute(base_file, '.css', '', '')
+    let base_file = substitute(base_file, '.scss', '', '')
+    let base_file = substitute(base_file, '.less', '', '')
     let file = base_file . '.spec.ts'
   endif 
   if expand('%') =~ 'component.spec.ts'

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -26,6 +26,8 @@ function! angular_cli#CreateEditCommands() abort
         \  ['V', 'vsplit'],
         \  ['T', 'tabnew'] ]
   for mode in modes
+    " TODO: ionic 4 with angular 6+ uses component.html and page.html, an
+    " elegant solution will solve for both.
     let elements_with_relation = 
           \[ ['Component', 'component.ts'],
           \  ['Module', 'module.ts'],
@@ -70,9 +72,13 @@ function! angular_cli#CreateGenerateCommands() abort
 endfunction
 
 function! angular_cli#CreateDefaultStyleExt() abort
-  let re = "\'" . '(?<=(?i)styleext.:..)\w+' . "\'"
-  let target = empty(glob('angular.json')) ? ' .angular-cli.json' : ' angular.json'
-  let g:angular_cli_stylesheet_format = system('grep -Po ' . re . target)[:-2]
+  let re = "\'" . '(?<=styleExt.:..).+(?=..)' . "\'"
+  let g:angular_cli_stylesheet_format = system(g:gnu_grep . ' -Po ' . re . ' .angular-cli.json')[:-2]
+  " assuming the correct grep command is set, if this is loaded but no
+  " .angular-cli is found, its probably ionic3 (scss)
+  if v:shell_error
+    g:angular_cli_stylesheet_format = 'scss'
+  endif
 endfunction
 
 function! angular_cli#CreateDestroyCommand() abort

--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -76,7 +76,7 @@ function! angular_cli#CreateDefaultStyleExt() abort
   " if this plugin was loaded but no ng config found, assume ionic 
   " (default .scss)
   if v:shell_error
-    let g:angular_cli_stylesheet_format = 'scss'
+    let g:angular_cli_stylesheet_format = 'css'
   endif
 endfunction
 

--- a/plugin/angular_cli.vim
+++ b/plugin/angular_cli.vim
@@ -6,6 +6,9 @@ if !exists('g:angular_cli_stylesheet_format')
   let g:angular_cli_stylesheet_format = 'css'
 endif
 
+if !exists('g:gnu_grep')
+  let g:gnu_grep = 'grep'
+endif
 
 " Moved to angular_cli#init() to be called manually by users.
 " call CreateEditCommands()


### PR DESCRIPTION
See updates to README. Also included code from [this PR](https://github.com/bdauria/angular-cli.vim/pull/15) so maybe pull that one first.

I apologize for the commits being a bit sloppy, I'm new to VimScript and I only work on it very very late at night after the real work is done 🙏 