### PR TITLE
quickfix stylesheet format detection

### DIFF
--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -72,11 +72,13 @@ endfunction
 function! angular_cli#CreateDefaultStyleExt() abort
   let re = "\'" . '(?<=styles\.).*(?=")' . "\'"
   let target = empty(glob('angular.json')) ? ' .angular-cli.json' : ' angular.json'
-  let g:angular_cli_stylesheet_format = systemlist(g:gnu_grep . ' -Po ' . re . target)[0]
-  " if this plugin was loaded but no ng config found, assume ionic 
-  " (default .scss)
+  let styles = systemlist(g:gnu_grep . ' -Po ' . re . target)
   if v:shell_error
-    g:angular_cli_stylesheet_format = 'scss'
+    " if this plugin was loaded but no ng config found, assume ionic 
+    " (default .scss)
+    let g:angular_cli_stylesheet_format = 'scss'
+  else
+    let g:angular_cli_stylesheet_format = styles[0]
   endif
 endfunction
 


### PR DESCRIPTION
The grepping that's done in CreateDefaultStyleExt on angular.json is not very reliable. 
For a certain project I get:
```
E684: list index out of range: 0
E15: Invalid expression: systemlist(g:gnu_grep . ' -Po ' . re . target)[0]
```
So the v:shell_error statement isn't reached when grep returns empty list.
It doesn't work when the styles in the JSON is on multiple lines.
This can be fixed by first checking the grep return codes before getting the first element.

On a side note:
It's also possible there are multiple style entries (each could be css or scss).
A better check might be to first try running ng config command and checking it's output:
`ng config schematics.@schematics/angular:component.styleext`
and then try
`ng config @ionic/angular-toolkit:component.styleext`

