### PR TITLE
Ensure substituting only the file extension at end of filename

### DIFF
--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -178,9 +178,9 @@ function! angular_cli#EditSpecFile(file, command) abort
       return
     endif
     let g:last_file_jump = expand('%')
-    let base_file = substitute(expand('%'), '.html', '', '')
-    let base_file = substitute(base_file, '.ts', '', '')
-    let base_file = substitute(base_file, '.' . g:angular_cli_stylesheet_format, '', '')
+    let base_file = substitute(expand('%'), '\.html$', '', '')
+    let base_file = substitute(base_file, '\.ts$', '', '')
+    let base_file = substitute(base_file, '\.' . g:angular_cli_stylesheet_format . '$', '', '')
     let file = base_file . '.spec.ts'
   endif 
   call angular_cli#EditFileIfExist(file, a:command, '.ts')


### PR DESCRIPTION
I was getting an error when trying to switch to my spec files and realized that the implementation of `substitute` was not specific enough.

This line:
```
let base_file = substitute(base_file, '.ts', '', '')
```
was removing any matches within the filepath, including in my case, the letters `ts` from my `components` directory.

I've updated to ensure that it actually matches on the dot in `.ts` and that it's matching on the end of the string.