### PR TITLE
Fix unavailable command in Vim 7

### DIFF
--- a/autoload/angular_cli.vim
+++ b/autoload/angular_cli.vim
@@ -72,7 +72,7 @@ endfunction
 function! angular_cli#CreateDefaultStyleExt() abort
   let re = "\'" . '(?<=styles\.).*(?=")' . "\'"
   let target = empty(glob('angular.json')) ? ' .angular-cli.json' : ' angular.json'
-  let styles = systemlist(g:gnu_grep . ' -Po ' . re . target)
+  let styles = split(system(g:gnu_grep . ' -Po ' . re . target), '\n')
   if v:shell_error
     " if this plugin was loaded but no ng config found, assume ionic 
     " (default .scss)


### PR DESCRIPTION
hi~~~

`systemlist` function is avarable since **vim 8**.

This commit is for old vim user. 
For example,developing with CentOS.